### PR TITLE
BUG: Bumped sklearn version requirement by a micro level.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scikit-learn~=0.18
+scikit-learn>=0.18.1
 scipy~=0.14
 numpy~=1.10
 pandas~=0.19

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scikit-learn>=0.18.1
+scikit-learn>=0.18.1,<0.20
 scipy~=0.14
 numpy~=1.10
 pandas~=0.19


### PR DESCRIPTION
Ensure the sklearn version is >= 0.18.1, per the bug in issue #3. 