### PR TITLE
BUG stacking get_params bugfix for estimator_list=[]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Fixed
+- In the stacking estimators, get_params no longer throws index error
+  when `estimator_list` is an empty list (#6)
+
 ## [0.1.0] - 2017-09-12
 
 ### Added

--- a/civismlext/stacking.py
+++ b/civismlext/stacking.py
@@ -96,11 +96,13 @@ class BaseStackedModel(BaseEstimator):
             return out
         # If deep, extract parameters from estimators too
         est_list = getattr(self, 'estimator_list')
-        out.update(self.named_base_estimators.copy())
-        out.update({self.meta_estimator_name: self.meta_estimator}.copy())
-        for name, estimator in est_list:
-            for key, value in estimator.get_params(deep=True).items():
-                out['%s__%s' % (name, key)] = value
+        # If est_list is an empty list, don't do anything else
+        if len(est_list) > 0:
+            out.update(self.named_base_estimators.copy())
+            out.update({self.meta_estimator_name: self.meta_estimator}.copy())
+            for name, estimator in est_list:
+                for key, value in estimator.get_params(deep=True).items():
+                    out['%s__%s' % (name, key)] = value
         return out
 
     def set_params(self, **params):

--- a/civismlext/test/test_stacking.py
+++ b/civismlext/test/test_stacking.py
@@ -200,6 +200,23 @@ def test_get_params(SM):
 
 
 @pytest.mark.parametrize('SM', [StackedClassifier, StackedRegressor])
+def test_get_params_estimator_list_empty(SM):
+    est_list = []
+
+    sm = SM(
+        est_list, cv=9, n_jobs=10, pre_dispatch=1, verbose=10)
+
+    # Check parameter getting
+    param_dict = dict(cv=9,
+                      estimator_list=est_list,
+                      n_jobs=10,
+                      pre_dispatch=1,
+                      verbose=10)
+    assert sm.get_params(deep=False) == param_dict
+    assert sm.get_params(deep=True) == param_dict
+
+
+@pytest.mark.parametrize('SM', [StackedClassifier, StackedRegressor])
 def test_set_params(SM):
     basic_est = BasicEst()
     meta_est = BasicEst()


### PR DESCRIPTION
Previously, stacking estimators with `estimator_list=[]` threw an `IndexError` when `get_params(deep=True)` was called. This PR fixes that bug.