### PR TITLE
BUG make sure to have `y=None` in the fit method definition

### DIFF
--- a/civismlext/preprocessing.py
+++ b/civismlext/preprocessing.py
@@ -208,6 +208,8 @@ class DataFrameETL(BaseEstimator, TransformerMixin):
         ----------
         X : pd.DataFrame
             Training or test data.
+        y : numpy array of shape [n_samples]
+            Ignored by this class.
 
         Returns
         -------

--- a/civismlext/preprocessing.py
+++ b/civismlext/preprocessing.py
@@ -201,7 +201,7 @@ class DataFrameETL(BaseEstimator, TransformerMixin):
         expanded_array[sentinel_entries, :] = 0.0
         return expanded_array
 
-    def fit(self, X):
+    def fit(self, X, y=None):
         """Fit the ETL pipeline.
 
         Parameters

--- a/civismlext/test/test_preprocessing.py
+++ b/civismlext/test/test_preprocessing.py
@@ -8,6 +8,21 @@ import numpy as np
 import pandas as pd
 from numpy.testing import assert_almost_equal
 from sklearn.exceptions import NotFittedError
+from sklearn.utils.estimator_checks import (
+    check_transformer_data_not_an_array,
+    check_transformer_general,
+    check_transformers_unfitted,
+    check_transformer_n_iter,
+    check_fit2d_predict1d,
+    check_fit2d_1sample,
+    check_fit2d_1feature,
+    check_fit1d_1feature,
+    check_fit1d_1sample,
+    check_get_params_invariance,
+    check_dict_unchanged,
+    check_dont_overwrite_parameters,
+    check_parameters_default_constructible,
+    check_no_fit_attributes_set_in_init)
 import pytest
 
 from civismlext.preprocessing import DataFrameETL
@@ -117,22 +132,6 @@ def levels_dict_numeric():
 
 
 def test_sklearn_api():
-    from sklearn.utils.estimator_checks import (
-        check_transformer_data_not_an_array,
-        check_transformer_general,
-        check_transformers_unfitted,
-        check_transformer_n_iter,
-        check_fit2d_predict1d,
-        check_fit2d_1sample,
-        check_fit2d_1feature,
-        check_fit1d_1feature,
-        check_fit1d_1sample,
-        check_get_params_invariance,
-        check_dict_unchanged,
-        check_dont_overwrite_parameters,
-        check_parameters_default_constructible,
-        check_no_fit_attributes_set_in_init)
-
     name = DataFrameETL.__name__
     check_parameters_default_constructible(name, DataFrameETL)
     check_no_fit_attributes_set_in_init(name, DataFrameETL)

--- a/civismlext/test/test_preprocessing.py
+++ b/civismlext/test/test_preprocessing.py
@@ -116,6 +116,53 @@ def levels_dict_numeric():
     return levels
 
 
+def test_sklearn_api():
+    from sklearn.utils.estimator_checks import (
+        check_transformer_data_not_an_array,
+        check_transformer_general,
+        check_transformers_unfitted,
+        check_transformer_n_iter,
+        check_fit2d_predict1d,
+        check_fit2d_1sample,
+        check_fit2d_1feature,
+        check_fit1d_1feature,
+        check_fit1d_1sample,
+        check_get_params_invariance,
+        check_dict_unchanged,
+        check_dont_overwrite_parameters,
+        check_parameters_default_constructible,
+        check_no_fit_attributes_set_in_init)
+
+    name = DataFrameETL.__name__
+    check_parameters_default_constructible(name, DataFrameETL)
+    check_no_fit_attributes_set_in_init(name, DataFrameETL)
+
+    estimator = DataFrameETL()
+
+    for check in [
+            check_transformers_unfitted,
+            check_transformer_n_iter,
+            check_get_params_invariance]:
+        check(name, estimator)
+
+    # these are known failures
+    for check in [
+            check_transformer_data_not_an_array,
+            check_transformer_general,
+            check_fit2d_predict1d,
+            check_fit2d_1sample,
+            check_fit2d_1feature,
+            check_fit1d_1feature,
+            check_fit1d_1sample,
+            check_dict_unchanged,
+            check_dont_overwrite_parameters]:
+        with pytest.raises(TypeError) as e:
+            check(name, estimator)
+        assert (
+            "ETL transformer must be fit "
+            "to a dataframe.") in str(e.value)
+
+
 def test_flag_numeric():
     test1 = [1, 'a', 'b']
     test2 = [5.55, 0, np.nan]


### PR DESCRIPTION
This PR makes sure we conform to the sklearn API spec. See [here](http://scikit-learn.org/stable/developers/contributing.html#fitting). Note that no doc strings are needed. See for example the PCA function, http://scikit-learn.org/stable/modules/generated/sklearn.decomposition.PCA.html#sklearn.decomposition.PCA.fit 