### PR TITLE
DEP update scipy version to include 1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.2.0] - Unreleased
+- Updated `scipy` dependency in `requirements.txt` file to `scipy>=0.14,<2.0`
+
 ## [0.1.5] - 2017-10-27
 
 ### Added

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 scikit-learn>=0.18.1,<0.20
-scipy~=0.14
+scipy>=0.14,<2.0
 numpy~=1.10
 pandas~=0.19
 six~=1.10


### PR DESCRIPTION
I think this ought to be a minor version bump. This is necessary if we're to update the `datascience-python` image.

cc @beckermr 