### PR TITLE
ENH Add debug log emits for DataFrameETL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+
+### Added
+- Added debug log emits for the ``DataFrameETL`` transformer (#24, #27)
+
 ## [0.1.6] - 2018-1-12
 
 ### Fixed


### PR DESCRIPTION
Logging is helpful in diagnosing errors. Add some debug log emits to the `DataFrameETL` to make it easier to pinpoint the source of future modeling problems.

Closes #24 .