### PR TITLE
BUG Preserve index of input DataFrame when transforming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Fixed
+- Fixed ``DataFrameETL`` transformations of ``DataFrame``s with non-trivial
+  index when preserving ``DataFrame`` output type (#32, #33)
 
 ## [0.1.7] - 2018-03-27
 ### Added

--- a/civismlext/preprocessing.py
+++ b/civismlext/preprocessing.py
@@ -279,8 +279,7 @@ class DataFrameETL(BaseEstimator, TransformerMixin):
                   str(X.shape), X.shape[0], len(self.columns_))
         if self.dataframe_output:
             # preallocate a dataframe
-            X_new = pd.DataFrame(index=np.arange(X.shape[0]),
-                                 columns=self.columns_)
+            X_new = pd.DataFrame(index=X.index, columns=self.columns_)
             # column index
             i = 0
             for col in self.required_columns_:

--- a/civismlext/test/test_preprocessing.py
+++ b/civismlext/test/test_preprocessing.py
@@ -632,6 +632,17 @@ def test_refit(data_raw, data_raw_2):
     assert df2.equals(df_expected_2)
 
 
+def test_dataframe_output_with_index():
+    # DataFrame output should preserve the index of the input
+    df = pd.DataFrame({'a': [1, 2, 3], 'b': ['x', 'y', 'x']}, index=[11, 8, 0])
+    df2 = DataFrameETL(dataframe_output=True, dummy_na=False).fit_transform(df)
+
+    df_exp = pd.DataFrame({'a': [1, 2, 3], 'b_x': [1, 0, 1], 'b_y': [0, 1, 0]},
+                          index=[11, 8, 0], dtype='float32')
+
+    assert df2.equals(df_exp)
+
+
 def test_pickle(data_raw):
     expander = DataFrameETL(cols_to_drop=['pid'],
                             cols_to_expand=['djinn_type', 'fruits', 'animal'],


### PR DESCRIPTION
Removing the index caused bad errors when inserting un-expanded columns from the original DataFrame into the new DataFrame. Users will probably also expect that their indexes are preserved.