### PR TITLE
BUG Restrict pandas version by Python minor version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - Fixed ``DataFrameETL`` transformations of ``DataFrame``s with non-trivial
   index when preserving ``DataFrame`` output type (#32, #33)
+- Add ``pandas`` version restrictions by Python version (#37)
 
 ## [0.1.7] - 2018-03-27
 ### Added

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 scikit-learn>=0.18.1,<0.20
 scipy>=0.14,<2.0
 numpy~=1.10
-pandas~=0.19
+pandas~=0.19; python_version >= '3.5'
+pandas>=0.19,<0.21; python_version == '3.4'
+pandas>=0.19,<=0.23; python_version == '2.7'
 six~=1.10


### PR DESCRIPTION
Pandas dropped Python 3.4 support with v0.21, and our Python 3.4 tests have recently begun failing when they attempt to install the newest version. In the project requirements, make sure that we're requiring versions of `pandas` which are compatible with the user's Python version.