### PR TITLE
Emit warning when fit and transform levels don't overlap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
-
+### Added
+- Emit a warning if the column levels during transform don't overlap
+  at all with levels from fitting (#41)
 
 ## [0.1.9] - 2018-05-17
 ### Fixed

--- a/civismlext/preprocessing.py
+++ b/civismlext/preprocessing.py
@@ -182,7 +182,7 @@ class DataFrameETL(BaseEstimator, TransformerMixin):
             warn_msg = "No overlap between levels in column " + \
                        "'%s' and levels seen during fit" % (col)
             warnings.warn(warn_msg, UserWarning)
-        
+
         if self._nan_sentinel not in catcol.cat.categories:
             catcol = catcol.cat.add_categories(self._nan_sentinel)
             sentinel_entries = None

--- a/civismlext/preprocessing.py
+++ b/civismlext/preprocessing.py
@@ -174,6 +174,15 @@ class DataFrameETL(BaseEstimator, TransformerMixin):
         # then it's a category not seen during the fit and should
         # be ignored in the expansion.
         catcol = X[col].astype('category')
+
+        # check for overlap between categories in col and original fit levels
+        overlap = len([lvl for lvl in catcol.cat.categories if
+                       lvl in self.levels_[col]])
+        if overlap == 0:
+            warn_msg = "No overlap between levels in column " + \
+                       "'%s' and levels seen during fit" % (col)
+            warnings.warn(warn_msg, UserWarning)
+        
         if self._nan_sentinel not in catcol.cat.categories:
             catcol = catcol.cat.add_categories(self._nan_sentinel)
             sentinel_entries = None

--- a/civismlext/test/test_preprocessing.py
+++ b/civismlext/test/test_preprocessing.py
@@ -701,3 +701,33 @@ def test_categorical_mixed_type_levels():
                     [3, 0, 1]])
     assert_almost_equal(tfm, exp)
     assert expander.columns_ == ['fruits', 'mixed_500', 'mixed_cat']
+
+
+def test_transform_different_dtype():
+    df = pd.concat([
+        pd.Series([1.0, np.NaN, 3.0], dtype='float', name='fruits'),
+        pd.Series(["2000", "2500", "3000"], dtype='object', name='age')
+    ], axis=1)
+
+    expander = DataFrameETL(cols_to_expand=['age'], dummy_na=False)
+    expander.fit(df)
+
+    print(df)
+    # DataFrame should enforce dtype after fitting
+    df['age'] = df['age'].astype('float').astype('object')
+    print(df)
+
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter('always')
+        out_arr = expander.transform(df)
+        # assert len(w) == 1
+
+    expected_arr = np.array([[1., 1., 0., 0.],
+                             [np.NaN, 0., 1., 0.],
+                             [3., 0., 0., 1.]])
+
+    print(out_arr)
+    assert_almost_equal(out_arr, expected_arr)
+    assert expander.columns_ == ['fruits', 'age_2000', 'age_2500', 'age_3000']
+    
+


### PR DESCRIPTION
If fit and transform levels for a given column don't overlap at all, there is probably an issue with the inputs, which can be hard or impossible for us to check/correct (dtype mismatch, misnamed column, etc.). Emitting a warning will help users catch errors that would otherwise occur silently.