### PR TITLE
ENH Error for columns with too many categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Added
+- Raise a RuntimeError if there are more than 5000 levels in a column (#42)
 - Emit a warning if the column levels during transform don't overlap
   at all with levels from fitting (#41)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+
 ### Added
 - Raise a RuntimeError if there are more than 5000 levels in a column (#42)
 - Emit a warning if the column levels during transform don't overlap

--- a/civismlext/preprocessing.py
+++ b/civismlext/preprocessing.py
@@ -57,7 +57,7 @@ class DataFrameETL(BaseEstimator, TransformerMixin):
         List of final column names in order
     """
     expansion_warn_threshold = 500  # Warn when expanding this many categories
-    expansion_exc_threshold = 5000 # Error when expanding this many categories
+    expansion_exc_threshold = 5000  # Error when expanding this many categories
 
     def __init__(self,
                  cols_to_drop=None,
@@ -114,8 +114,8 @@ class DataFrameETL(BaseEstimator, TransformerMixin):
             if (self.expansion_warn_threshold and
                     len(levels[col]) >= self.expansion_warn_threshold):
                 warn_list[col] = len(levels[col])
-            if (self.expansion_error_threshold and
-                    len(levels[col]) >= self.expansion_error_threshold):
+            if (self.expansion_exc_threshold and
+                    len(levels[col]) >= self.expansion_exc_threshold):
                 error_list[col] = len(levels[col])
             # if there are nans, we will be replacing them with a sentinel,
             # so add the sentinel as a level explicitly
@@ -133,6 +133,16 @@ class DataFrameETL(BaseEstimator, TransformerMixin):
                           ("; ".join(['"%s": %d categories' % (c, l)
                                       for c, l in warn_list.items()])),
                           RuntimeWarning)
+        if error_list:
+            err = ("The following column(s) have a very large number of "
+                   "categories and may use up too much memory if expanded. "
+                   "If you are sure you want to expand these features, "
+                   "manually update the expansion_exc_threshold attribute "
+                   "and rerun. Otherwise, exclude these columns from "
+                   "categorical expansion.\n%s" %
+                   ("; ".join(['"%s": %d categories' % (c, l)
+                               for c, l in error_list.items()])))
+            raise RuntimeError(err)
         return levels
 
     def _create_col_names(self, X):

--- a/civismlext/preprocessing.py
+++ b/civismlext/preprocessing.py
@@ -57,6 +57,7 @@ class DataFrameETL(BaseEstimator, TransformerMixin):
         List of final column names in order
     """
     expansion_warn_threshold = 500  # Warn when expanding this many categories
+    expansion_exc_threshold = 5000 # Error when expanding this many categories
 
     def __init__(self,
                  cols_to_drop=None,
@@ -104,6 +105,7 @@ class DataFrameETL(BaseEstimator, TransformerMixin):
         """Create levels for each column in cols_to_expand."""
         levels = {}
         warn_list = {}
+        error_list = {}
         # get a list of categories when the column is cast to
         # dtype category
         # levels are sorted by default
@@ -112,6 +114,9 @@ class DataFrameETL(BaseEstimator, TransformerMixin):
             if (self.expansion_warn_threshold and
                     len(levels[col]) >= self.expansion_warn_threshold):
                 warn_list[col] = len(levels[col])
+            if (self.expansion_error_threshold and
+                    len(levels[col]) >= self.expansion_error_threshold):
+                error_list[col] = len(levels[col])
             # if there are nans, we will be replacing them with a sentinel,
             # so add the sentinel as a level explicitly
             # Note that even if we don't include a dummy_na column, we still

--- a/civismlext/test/test_preprocessing.py
+++ b/civismlext/test/test_preprocessing.py
@@ -242,6 +242,14 @@ def test_warn_too_many_categories():
     assert '"bird": 1000 categories' in warn[0].message.args[0]
 
 
+def test_exc_way_too_many_categories():
+    df = pd.DataFrame({'cat': list(range(5500)),
+                       'bird': list(range(5500))})
+    with pytest.raises(RuntimeError) as exc:
+        DataFrameETL(cols_to_expand=['cat', 'bird']).fit(df)
+    assert '"cat": 5500 categories' in exc.value
+    assert '"bird": 5500 categories' in exc.value
+
 def test_create_col_names(data_raw):
     expander = DataFrameETL(cols_to_expand=['pid', 'djinn_type', 'animal'],
                             cols_to_drop=['fruits'],

--- a/civismlext/test/test_preprocessing.py
+++ b/civismlext/test/test_preprocessing.py
@@ -247,8 +247,9 @@ def test_exc_way_too_many_categories():
                        'bird': list(range(5500))})
     with pytest.raises(RuntimeError) as exc:
         DataFrameETL(cols_to_expand=['cat', 'bird']).fit(df)
-    assert '"cat": 5500 categories' in exc.value
-    assert '"bird": 5500 categories' in exc.value
+    assert '"cat": 5500 categories' in str(exc.value)
+    assert '"bird": 5500 categories' in str(exc.value)
+
 
 def test_create_col_names(data_raw):
     expander = DataFrameETL(cols_to_expand=['pid', 'djinn_type', 'animal'],


### PR DESCRIPTION
This PR adds an error for columns with more than 5000 categories. I kept the warning for more than 500 categories, and raise the exception after issuing the warning so that the user can see all problem columns (there will be overlap; I thought it might be more confusing to exclude error columns from the warning list).

I set the cutoff as a class attribute similar to the warnings, but this means that there isn't a good way for users to override the exception from within CivisML (they can't add it as a parameter, although they can pass their own instantiated ETL transformer). I'm torn between wanting to keep consistent and wanting to allow users to override, and I'm open to changing it.