### PR TITLE
ENH add option for dummying all columns with NA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,8 @@ install:
     - pip install --upgrade pip setuptools
     - pip install -r dev-requirements.txt
     - pip install -r requirements.txt
-    - pip install pandas==0.19 ; python_version==3.5
     - pip install cython ; python_version==3.6
+    - pip install pandas==0.19 ; python_version==3.5
     - pip install -e .
 before_script: flake8 civismlext
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ install:
     - pip install -r dev-requirements.txt
     - pip install -r requirements.txt
     - pip install pandas==0.19 ; python_version==3.5
-    - pip install pandas==0.19 ; python_version==3.6
+    - pip install cython ; python_version==3.6
     - pip install -e .
 before_script: flake8 civismlext
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,8 @@ install:
     - pip install --upgrade pip setuptools
     - pip install -r dev-requirements.txt
     - pip install -r requirements.txt
-    - pip install pandas==0.19 ; python_version>=3.5
+    - pip install pandas==0.19 ; python_version==3.5
+    - pip install pandas==0.19 ; python_version==3.6
     - pip install -e .
 before_script: flake8 civismlext
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
     - pip install --upgrade pip setuptools
     - pip install -r dev-requirements.txt
     - pip install -r requirements.txt
-    - pip install pandas==0.19 ; python_version==3.5
+    - pip install pandas==0.19 ; python_version>=3.5
     - pip install -e .
 before_script: flake8 civismlext
 script:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Changed
-- Instead of boolean flag for `dummy_na`, have False (no dummying),
+- Instead of boolean flag for `dummy_na`, have None/False (no dummying),
   'expanded' (matches previous True behavior), and 'all' (dummy NAs
   in all columns where they appear, not just ones we're categorically
   expanding). (#44)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+### Changed
+- Instead of boolean flag for `dummy_na`, have False (no dummying),
+  'expanded' (matches previous True behavior), and 'all' (dummy NAs
+  in all columns where they appear, not just ones we're categorically
+  expanding). (#44)
 
 ## [0.1.10] - 2019-01-16
 ### Added

--- a/civismlext/preprocessing.py
+++ b/civismlext/preprocessing.py
@@ -18,6 +18,7 @@ class DataFrameETL(BaseEstimator, TransformerMixin):
     """Performs ETL on a dataframe, using the following steps:
     - dropping specified columns
     - performing categorical expansion on a specified set of columns
+    - creating dummy columns for missing data in a specified set of columns
     - converting the dataframe to a numpy array or dataframe of float32s.
 
     Parameters
@@ -29,8 +30,13 @@ class DataFrameETL(BaseEstimator, TransformerMixin):
         - "auto": All non-numeric columns will be expanded.
         - None: no columns will be expanded.
         - list[str]: list of column names to expand.
-    dummy_na : bool, (default: True)
-        Add a column to indicate missing values.
+    dummy_na : {None, False, 'all', 'expanded'}, (default: 'all')
+        Options for adding indicator columns for missing values:
+        - None or False: do not add indicator columns for missing values
+        - 'all': add indicator columns for all columns with missing values
+          in fit data
+        - 'expanded': add indicator columns for all categorically expanded
+          columns (matches `True` behavior from version 1)
     fill_value : {float, np.nan}, (default: 0.0)
         The value to fill for missing values with in expanded columns.
         Can be a float or np.nan.
@@ -62,12 +68,18 @@ class DataFrameETL(BaseEstimator, TransformerMixin):
     def __init__(self,
                  cols_to_drop=None,
                  cols_to_expand='auto',
-                 dummy_na=True,
+                 dummy_na='all',
                  fill_value=0.0,
                  dataframe_output=False,
                  check_null_cols=False):
         self.cols_to_drop = cols_to_drop
         self.cols_to_expand = cols_to_expand
+        if dummy_na is True:
+            warnings.warn(
+                '`True` option for dummy_na is deprecated, use '
+                '"all" or "expanded" instead',
+                DeprecationWarning
+            )
         self.dummy_na = dummy_na
         self.fill_value = fill_value
         self.dataframe_output = dataframe_output
@@ -121,11 +133,12 @@ class DataFrameETL(BaseEstimator, TransformerMixin):
             # so add the sentinel as a level explicitly
             # Note that even if we don't include a dummy_na column, we still
             # need to keep track of missing values internally for fill_value
-            if self.dummy_na or any(X[col].isnull()):
+            if self._dummy_na == 'expanded' or any(X[col].isnull()):
                 levels[col].extend([self._nan_sentinel])
         log.debug("Categories (including nulls) for each column: %s",
                   "; ".join('"%s": %d' % (c, len(l))
                             for c, l in levels.items()))
+
         if warn_list:
             warnings.warn("The following categorical column(s) have a large "
                           "number of categories. Are you sure you wish to "
@@ -145,6 +158,19 @@ class DataFrameETL(BaseEstimator, TransformerMixin):
             raise RuntimeError(err)
         return levels
 
+    def _flag_unexpanded_nans(self, X):
+        """Optionally create levels for columns we don't want to expand,
+        but have nulls."""
+        unexpanded_nans = {}
+        skip_cols = set(self._cols_to_drop + self._cols_to_expand)
+        for col in X.columns:
+            if col not in skip_cols:
+                if self._dummy_na == 'all' and any(X[col].isnull()):
+                    unexpanded_nans[col] = True
+                else:
+                    unexpanded_nans[col] = False
+        return unexpanded_nans
+
     def _create_col_names(self, X):
         """Identify levels and build an ordered list of final column names."""
         # get unexpanded columns, remove any that need dropping
@@ -157,7 +183,7 @@ class DataFrameETL(BaseEstimator, TransformerMixin):
         for col in unexpanded_cnames:
             if col in self._cols_to_expand:
                 col_levels = self.levels_[col]
-                if self.dummy_na:
+                if self._dummy_na in ['expanded', 'all']:
                     # avoid exposing the sentinel to the user by replacing
                     # it with 'NaN'. If 'NaN' is already a level, use the
                     # sentinel to prevent column name duplicates.
@@ -179,7 +205,9 @@ class DataFrameETL(BaseEstimator, TransformerMixin):
                 cnames.extend(expanded_names)
             else:
                 cnames.append(col)
-
+                # Add columns for nulls in unexpanded columns
+                if self.unexpanded_nans[col]:
+                    cnames.append('%s_NaN' % (col))
         return cnames, unexpanded_cnames
 
     def _expand_col(self, X, col):
@@ -216,7 +244,7 @@ class DataFrameETL(BaseEstimator, TransformerMixin):
         is_nan = (newcat == self._nan_sentinel)
         if is_nan.any():
             expanded_array[is_nan, :-1] = self.fill_value
-            if not self.dummy_na:
+            if not self._dummy_na:
                 # Drop the last column, which is the nan column
                 expanded_array = expanded_array[:, :-1]
 
@@ -242,6 +270,17 @@ class DataFrameETL(BaseEstimator, TransformerMixin):
         """
         if not isinstance(X, pd.DataFrame):
             raise TypeError("ETL transformer must be fit to a dataframe.")
+
+        # TODO: remove in version 1.0.0
+        if self.dummy_na is True:
+            self._dummy_na = 'expanded'
+        else:
+            self._dummy_na = self.dummy_na
+
+        # check that a valid dummy_na value passed in
+        valid_options = [None, False, 'all', 'expanded']
+        if self._dummy_na not in valid_options:
+            raise ValueError('dummy_na must be one of %s' % valid_options)
 
         # set default values
         #  _nan_sentinel is a temporary sentinel for np.nan values
@@ -272,6 +311,9 @@ class DataFrameETL(BaseEstimator, TransformerMixin):
             # Update sentinels if the defaults are in the dataframe
             self._check_sentinels(X)
             self.levels_ = self._create_levels(X)
+
+        # optionally flag unexpanded columns with nans
+        self.unexpanded_nans = self._flag_unexpanded_nans(X)
 
         # Get colummn names in order
         self.columns_, self.required_columns_ = self._create_col_names(X)
@@ -323,6 +365,9 @@ class DataFrameETL(BaseEstimator, TransformerMixin):
                     # put the column in the array
                     X_new.iloc[:, i] = X[col].astype('float32')
                     i += 1
+                    if self.unexpanded_nans[col]:
+                        X_new.iloc[:, i] = X[col].isnull().astype('float32')
+                        i += 1
         else:
             # preallocate an array
             ncol = len(self.columns_)
@@ -340,5 +385,8 @@ class DataFrameETL(BaseEstimator, TransformerMixin):
                     # put the column in the array
                     X_new[:, i] = X[col].astype('float32')
                     i += 1
+                    if self.unexpanded_nans[col]:
+                        X_new[:, i] = X[col].isnull().astype('float32')
+                        i += 1
 
         return X_new

--- a/civismlext/preprocessing.py
+++ b/civismlext/preprocessing.py
@@ -188,8 +188,8 @@ class DataFrameETL(BaseEstimator, TransformerMixin):
                     # it with 'NaN'. If 'NaN' is already a level, use the
                     # sentinel to prevent column name duplicates.
                     # Note that for "expanded", all expanded features will have
-                    # a dummied NaN column, which for "all", features with nulls
-                    # (expanded or not) will have a dummied NaN column.
+                    # a dummied NaN column, which for "all", features with
+                    # nulls (expanded or not) will have a dummied NaN column.
                     if 'NaN' in col_levels:
                         expanded_names = ['%s_%s' % (col, self._nan_sentinel)
                                           if cat == self._nan_sentinel

--- a/civismlext/test/test_preprocessing.py
+++ b/civismlext/test/test_preprocessing.py
@@ -201,7 +201,7 @@ def test_check_sentinels(data_raw):
     expander._cols_to_drop = expander.cols_to_drop
     expander._cols_to_expand = expander.cols_to_expand
     expander._check_sentinels(data_raw)
-    assert expander._nan_sentinel is not 'effrit'
+    assert expander._nan_sentinel != 'effrit'
     assert not (data_raw[['pid', 'djinn_type', 'animal']] ==
                 expander._nan_sentinel).any().any()
 

--- a/civismlext/test/test_preprocessing.py
+++ b/civismlext/test/test_preprocessing.py
@@ -771,6 +771,7 @@ def test_expand_all_na(data_raw):
     df_out = expander.transform(data_raw)
     assert df_out.equals(df_expected)
 
+
 @pytest.mark.skipif(sys.version_info < (3,), reason='requires python 3')
 def test_dummy_na_true_deprecated(data_raw):
     with warnings.catch_warnings(record=True) as w:

--- a/civismlext/test/test_preprocessing.py
+++ b/civismlext/test/test_preprocessing.py
@@ -4,6 +4,7 @@ from __future__ import division
 import pickle
 import io
 import warnings
+import sys
 
 import numpy as np
 import pandas as pd
@@ -770,7 +771,7 @@ def test_expand_all_na(data_raw):
     df_out = expander.transform(data_raw)
     assert df_out.equals(df_expected)
 
-
+@pytest.mark.skipif(sys.version_info < (3,), reason='requires python 3')
 def test_dummy_na_true_deprecated(data_raw):
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter('always')

--- a/civismlext/test/test_preprocessing.py
+++ b/civismlext/test/test_preprocessing.py
@@ -263,7 +263,7 @@ def test_create_col_names(data_raw):
     expander._cols_to_expand = expander.cols_to_expand
     expander._dummy_na = 'expanded'
     expander.levels_ = expander._create_levels(data_raw)
-    expander.unexpanded_nans = expander._flag_unexpanded_nans(data_raw)
+    expander._unexpanded_nans = expander._flag_unexpanded_nans(data_raw)
     (cnames, unexpanded) = expander._create_col_names(data_raw)
     cols_expected = ['pid_a', 'pid_b', 'pid_c', 'pid_NaN',
                      'djinn_type_effrit', 'djinn_type_marid',
@@ -282,7 +282,7 @@ def test_create_col_names_no_dummy(data_raw):
     expander._cols_to_expand = expander.cols_to_expand
     expander._dummy_na = False
     expander.levels_ = expander._create_levels(data_raw)
-    expander.unexpanded_nans = expander._flag_unexpanded_nans(data_raw)
+    expander._unexpanded_nans = expander._flag_unexpanded_nans(data_raw)
     (cnames, unexpanded) = expander._create_col_names(data_raw)
     cols_expected = ['pid_a', 'pid_b', 'pid_c',
                      'djinn_type_effrit', 'djinn_type_marid',
@@ -301,7 +301,7 @@ def test_create_col_names_numeric(data_raw):
     expander._cols_to_expand = expander.cols_to_expand
     expander._dummy_na = 'expanded'
     expander.levels_ = expander._create_levels(data_raw)
-    expander.unexpanded_nans = expander._flag_unexpanded_nans(data_raw)
+    expander._unexpanded_nans = expander._flag_unexpanded_nans(data_raw)
     (cnames, unexpanded) = expander._create_col_names(data_raw)
     cols_numeric = ['pid_a', 'pid_b', 'pid_c', 'pid_NaN', 'fruits_1.0',
                     'fruits_3.0', 'fruits_NaN', 'age']
@@ -766,7 +766,7 @@ def test_expand_all_na(data_raw):
                             dummy_na='all',
                             dataframe_output=True)
     expander.fit(data_raw)
-    assert expander.unexpanded_nans == {'fruits': True}
+    assert expander._unexpanded_nans == {'fruits': True}
 
     df_out = expander.transform(data_raw)
     assert df_out.equals(df_expected)
@@ -784,9 +784,11 @@ def test_dummy_na_true_deprecated(data_raw):
 
 
 def test_dummy_na_bad_value(data_raw):
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as exc:
         expander = DataFrameETL(cols_to_drop=['pid'],
                                 cols_to_expand=['djinn_type',
                                                 'fruits', 'animal'],
                                 dummy_na="bad_value")
         expander.fit(data_raw)
+    assert str(exc.value) == "dummy_na must be one of " + \
+        "[None, False, 'all', 'expanded']"

--- a/civismlext/test/test_preprocessing.py
+++ b/civismlext/test/test_preprocessing.py
@@ -772,6 +772,36 @@ def test_expand_all_na(data_raw):
     assert df_out.equals(df_expected)
 
 
+def test_na_in_transform_but_not_fit_all():
+    fit_df = pd.concat([
+        pd.Series(['marid', 'effrit', 'sila'], dtype='object',
+                  name='djinn_type'),
+        pd.Series([1.0, 2.0, 3.0], dtype='float', name='fruits'),
+    ], axis=1)
+
+    expander = DataFrameETL(cols_to_expand=['djinn_type'],
+                            dummy_na='all',
+                            dataframe_output=True)
+    expander.fit(fit_df)
+
+    # Add nans in the first row of pid and djinn_type for transforming
+    transform_df = pd.concat([
+        pd.Series([np.nan, 'effrit', 'sila'], dtype='object',
+                  name='djinn_type'),
+        pd.Series([np.nan, 2.0, 3.0], dtype='float', name='fruits'),
+        ], axis=1)
+    df = expander.transform(transform_df)
+
+    df_expected = pd.concat([
+        pd.Series([0., 1., 0.], dtype='float32', name='djinn_type_effrit'),
+        pd.Series([0., 0., 0.], dtype='float32', name='djinn_type_marid'),
+        pd.Series([0., 0., 1.], dtype='float32', name='djinn_type_sila'),
+        pd.Series([np.nan, 2.0, 3.0], dtype='float32', name='fruits'),
+    ], axis=1)
+
+    assert df.equals(df_expected)
+
+
 @pytest.mark.skipif(sys.version_info < (3,), reason='requires python 3')
 def test_dummy_na_true_deprecated(data_raw):
     with warnings.catch_warnings(record=True) as w:


### PR DESCRIPTION
This PR adds new options to `DataFrameETL` through the `dummy_na` parameter. The old behavior was (with default `True`):
- `dummy_na=True`: create a NaN column for all categorically expanded columns
- `dummy_na=False`: do not create any NaN indicator columns

Users may want NaN indicator columns for any columns with missing data, not just categorical columns. The new behavior is (with default `'all'`):
- `dummy_na=False` and `dummy_na=None`: do not create any NaN indicator columns
- `dummy_na='expanded'`: matches the `True` behavior in the previous version
- `dummy_na='all'`: create a NaN column for all columns with missing data

Note that some columns which get a NaN indicator when `dummy_na='expanded'` may not get an indicator when `dummy_na='all'` (that is, columns which are expanded, but don't have missing data). I'm concerned this may be confusing for users, but it seems more confusing to have an option which creates indicators for all expanded columns, but only for unexpanded columns with missing data. Creating an indicator for all columns regardless of missing data seems quite memory inefficient, and I wanted to keep an option that preserved backwards compatibility. I'm open to suggestions if this seems too confusing for users.