### PR TITLE
Allow sklearn >=0.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 ### Changed
+- Update tests and requirements.txt to allow sklearn 0.20 and above. (#47)
 - Instead of boolean flag for `dummy_na`, have None/False (no dummying),
   'expanded' (matches previous True behavior), and 'all' (dummy NAs
   in all columns where they appear, not just ones we're categorically

--- a/civismlext/test/test_preprocessing.py
+++ b/civismlext/test/test_preprocessing.py
@@ -22,8 +22,7 @@ from sklearn.utils.estimator_checks import (
     check_get_params_invariance,
     check_dict_unchanged,
     check_dont_overwrite_parameters,
-    check_parameters_default_constructible,
-    check_no_attributes_set_in_init)
+    check_parameters_default_constructible)
 import pytest
 
 from civismlext.preprocessing import DataFrameETL

--- a/civismlext/test/test_preprocessing.py
+++ b/civismlext/test/test_preprocessing.py
@@ -18,13 +18,12 @@ from sklearn.utils.estimator_checks import (
     check_fit2d_predict1d,
     check_fit2d_1sample,
     check_fit2d_1feature,
-    check_fit1d_1feature,
-    check_fit1d_1sample,
+    check_fit1d,
     check_get_params_invariance,
     check_dict_unchanged,
     check_dont_overwrite_parameters,
     check_parameters_default_constructible,
-    check_no_fit_attributes_set_in_init)
+    check_no_attributes_set_in_init)
 import pytest
 
 from civismlext.preprocessing import DataFrameETL
@@ -135,7 +134,7 @@ def levels_dict_numeric():
 def test_sklearn_api():
     name = DataFrameETL.__name__
     check_parameters_default_constructible(name, DataFrameETL)
-    check_no_fit_attributes_set_in_init(name, DataFrameETL)
+    # check_no_attributes_set_in_init(name, DataFrameETL)
 
     estimator = DataFrameETL()
 
@@ -152,8 +151,7 @@ def test_sklearn_api():
             check_fit2d_predict1d,
             check_fit2d_1sample,
             check_fit2d_1feature,
-            check_fit1d_1feature,
-            check_fit1d_1sample,
+            check_fit1d,
             check_dict_unchanged,
             check_dont_overwrite_parameters]:
         with pytest.raises(TypeError) as e:

--- a/civismlext/test/test_preprocessing.py
+++ b/civismlext/test/test_preprocessing.py
@@ -133,7 +133,6 @@ def levels_dict_numeric():
 def test_sklearn_api():
     name = DataFrameETL.__name__
     check_parameters_default_constructible(name, DataFrameETL)
-    # check_no_attributes_set_in_init(name, DataFrameETL)
 
     estimator = DataFrameETL()
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,4 +3,4 @@ flake8
 nose
 mock==2.0.0 ; python_version >= '2.7' and python_version < '3.0'
 # Estimator checks in test_preprocessing are sklearn>0.20 only
-scikit-learn>=0.20
+scikit-learn>=0.20,<0.22

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,3 +2,5 @@ pytest~=3.2
 flake8
 nose
 mock==2.0.0 ; python_version >= '2.7' and python_version < '3.0'
+# Estimator checks in test_preprocessing are sklearn>0.20 only
+scikit-learn>=0.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scikit-learn>=0.18.1,<0.20
+scikit-learn>=0.18.1
 scipy>=0.14,<2.0
 numpy~=1.10
 pandas~=0.19; python_version >= '3.5'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scikit-learn>=0.18.1
+scikit-learn>=0.18.1,<0.22
 scipy>=0.14,<2.0
 numpy~=1.10
 pandas~=0.19; python_version >= '3.5'


### PR DESCRIPTION
Several tests relied on attributes and checks which were not compatible with sklearn 0.20 and above. This PR includes the following changes:
* Removes check for `.grid_scores_` attribute in hyperband
* Uses updated estimator checks for `DataFrameETL`
* Sets stricter sklearn requirement in dev-requirements only, since changes only affected the test suite
* Updated `assert_true` and `assert_false` checks to use `assert`, squashing some deprecation warnings
* Added default arguments to `LogisticRegression` and `RandomForest` estimators, squashing some `FutureWarnings` about changing default args

Closes #45.