### PR TITLE
[PARO-736] Remove sklearn version's upper bound; Turn on Python 3.7 and 3.8 for Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ python:
     - "3.5"
     - "3.6"
     - "3.7"
+    - "3.8"
 install:
     - pip install --upgrade pip setuptools
     - pip install -r dev-requirements.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
     - "3.4"
     - "3.5"
     - "3.6"
+    - "3.7"
 install:
     - pip install --upgrade pip setuptools
     - pip install -r dev-requirements.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
-## [0.2.0] - 2019-11-22
+## [0.2.0] - 2019-12-11
 ### Changed
+- Removed the upper version bound for sklearn. (#50)
 - Update tests and requirements.txt to allow sklearn 0.20 and above. (#47)
 - Instead of boolean flag for `dummy_na`, have None/False (no dummying),
   'expanded' (matches previous True behavior), and 'all' (dummy NAs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.2.0] - 2019-12-11
 ### Added
-- Turn on Python 3.7 for Travis CI builds. (#50)
+- Turn on Python 3.7 and 3.8 for Travis CI builds. (#50)
 
 ### Changed
 - Removed the upper version bound for sklearn. (#50)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 ## [0.2.0] - 2019-12-11
+### Added
+- Turn on Python 3.7 for Travis CI builds. (#50)
+
 ### Changed
 - Removed the upper version bound for sklearn. (#50)
 - Update tests and requirements.txt to allow sklearn 0.20 and above. (#47)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,4 +3,4 @@ flake8
 nose
 mock==2.0.0 ; python_version >= '2.7' and python_version < '3.0'
 # Estimator checks in test_preprocessing are sklearn>0.20 only
-scikit-learn>=0.20,<0.22
+scikit-learn>=0.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-scikit-learn>=0.18.1,<0.22
+scikit-learn>=0.18.1
 scipy>=0.14,<2.0
 numpy~=1.10
 pandas~=0.19; python_version >= '3.5'


### PR DESCRIPTION
scikit-learn 0.22 just came out this week, and we need to make sure civisml-extensions works with this new version of sklearn as well. Also noticed that we didn't turn on Python 3.7 and 3.8 for Travis CI builds.