### PR TITLE
Make stacking compatible with sklearn 0.22.1; bump version to 0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [0.2.1] - 2020-01-15
+### Changed
+- Make stacking compatible with scikit-learn v0.22.1. (#52)
+
 ## [0.2.0] - 2019-12-11
 ### Added
 - Turn on Python 3.7 and 3.8 for Travis CI builds. (#50)

--- a/README.rst
+++ b/README.rst
@@ -31,21 +31,21 @@ example of using the ``StackedClassifier``:
 
     .. code-block:: python
 
-    >>> from sklearn.linear_model import LogisticRegression
-    >>> from sklearn.ensemble import RandomForestClassifier
-    >>> from civismlext.stacking import StackedClassifier
-    >>> # Note that the final estimator 'metalr' is the meta-estimator
-    >>> estlist = [('rf', RandomForestClassifier()),
-    >>>            ('lr', LogisticRegression()),
-    >>>            ('metalr', LogisticRegression())]
-    >>> mysm = StackedClassifier(estlist)
-    >>> # Set some parameters, if you didn't set them at instantiation
-    >>> mysm.set_params(rf__random_state=7, lr__random_state=8,
-    >>>                 metalr__random_state=9, metalr__C=10**7)
-    >>> # Fit
-    >>> mysm.fit(Xtrain, ytrain)
-    >>> # Predict!
-    >>> ypred = mysm.predict_proba(Xtest)
+        >>> from sklearn.linear_model import LogisticRegression
+        >>> from sklearn.ensemble import RandomForestClassifier
+        >>> from civismlext.stacking import StackedClassifier
+        >>> # Note that the final estimator 'metalr' is the meta-estimator
+        >>> estlist = [('rf', RandomForestClassifier()),
+        >>>            ('lr', LogisticRegression()),
+        >>>            ('metalr', LogisticRegression())]
+        >>> mysm = StackedClassifier(estlist)
+        >>> # Set some parameters, if you didn't set them at instantiation
+        >>> mysm.set_params(rf__random_state=7, lr__random_state=8,
+        >>>                 metalr__random_state=9, metalr__C=10**7)
+        >>> # Fit
+        >>> mysm.fit(Xtrain, ytrain)
+        >>> # Predict!
+        >>> ypred = mysm.predict_proba(Xtest)
 
 You can learn more about stacking and see an example use of the  ``StackedRegressor`` and ``NonNegativeLinearRegression`` estimators in `a talk presented at PyData NYC`_ in November, 2017.
 

--- a/setup.py
+++ b/setup.py
@@ -18,5 +18,6 @@ setup(version=_VERSION,
       packages=find_packages(),
       install_requires=read('requirements.txt').splitlines(),
       long_description=read('README.rst'),
+      long_description_content_type='text/x-rst',
       include_package_data=True,
       license="BSD-3")

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def read(fname):
         return _in.read()
 
 
-_VERSION = '0.2.0'
+_VERSION = '0.2.1'
 
 setup(version=_VERSION,
       name="civisml-extensions",


### PR DESCRIPTION
The stacking module used a scikit-learn private function that has been removed from the latest scikit-learn 0.22.1 (see https://github.com/scikit-learn/scikit-learn/pull/15863). This PR puts in a workaround for that. Also bumping civisml-extensions version to v0.2.1 for a release after this PR is in.

Locally, I tested this PR by running the test suite under both scikit-learn v0.22.1 (= what Travis CI would use at this PR) and v0.22. With v0.22, I confirm that all tests passed and that the added `FutureWarning` showed up as intended.