### PR TITLE
Fixed Deprecated Package(s) Dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+git:
+	git add .
+	git commit -m "$m"
+	git push -u

--- a/README.rst
+++ b/README.rst
@@ -34,16 +34,23 @@ example of using the ``StackedClassifier``:
         >>> from sklearn.linear_model import LogisticRegression
         >>> from sklearn.ensemble import RandomForestClassifier
         >>> from civismlext.stacking import StackedClassifier
+        >>> 
+        >>> # Define some Train data and labels
+        >>> Xtrain, ytrain = <train_features>, <train_labels>
+        >>> 
         >>> # Note that the final estimator 'metalr' is the meta-estimator
         >>> estlist = [('rf', RandomForestClassifier()),
         >>>            ('lr', LogisticRegression()),
         >>>            ('metalr', LogisticRegression())]
+        >>> 
         >>> mysm = StackedClassifier(estlist)
         >>> # Set some parameters, if you didn't set them at instantiation
         >>> mysm.set_params(rf__random_state=7, lr__random_state=8,
         >>>                 metalr__random_state=9, metalr__C=10**7)
+        >>> 
         >>> # Fit
         >>> mysm.fit(Xtrain, ytrain)
+        >>> 
         >>> # Predict!
         >>> ypred = mysm.predict_proba(Xtest)
 
@@ -54,7 +61,7 @@ See the doc strings of the various estimators for more information.
 Contributing
 ------------
 
-See ``CONTRIBUTING.md`` for information about contributing to this project.
+Please see ``CONTRIBUTING.md`` for information about contributing to this project.
 
 License
 -------

--- a/civismlext/hyperband.py
+++ b/civismlext/hyperband.py
@@ -3,11 +3,13 @@ from __future__ import division
 
 from collections import defaultdict
 from functools import partial
+
 import copy
 import itertools
 import logging
 
 import numpy as np
+from joblib import Parallel, delayed
 from scipy.stats import rankdata
 
 from sklearn.model_selection import ParameterSampler
@@ -18,7 +20,6 @@ from sklearn.model_selection import check_cv
 # I don't want this, but fine.
 from sklearn.model_selection._validation import _fit_and_score
 
-from sklearn.externals.joblib import Parallel, delayed
 from sklearn.utils.fixes import MaskedArray
 from sklearn.utils.validation import indexable
 from sklearn.metrics.scorer import check_scoring
@@ -490,7 +491,8 @@ class HyperbandSearchCV(BaseSearchCV):
                 # An all masked empty array gets created for the key
                 # `"param_%s" % name` at the first occurence of `name`.
                 # Setting the value at an index also unmasks that index
-                param_results["param_%s" % name][cand_i] = value
+                # breakpoint()
+                param_results.get("param_" + name).get(cand_i) = value
 
         results.update(param_results)
 

--- a/civismlext/stacking.py
+++ b/civismlext/stacking.py
@@ -2,15 +2,17 @@ from __future__ import print_function
 from __future__ import division
 
 from abc import ABCMeta, abstractmethod
-import warnings
 
 import numpy as np
 import six
+import warnings
+
+from joblib import Parallel, delayed
+
 from sklearn.base import BaseEstimator, clone
 from sklearn.utils.metaestimators import if_delegate_has_method
 from sklearn.model_selection import check_cv
 from sklearn.utils import tosequence, check_X_y
-from sklearn.externals.joblib import Parallel, delayed
 
 try:
     # TODO: Avoid using a private function from scikit-learn.

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pandas~=0.19; python_version >= '3.5'
 pandas>=0.19,<0.21; python_version == '3.4'
 pandas>=0.19,<=0.23; python_version == '2.7'
 six~=1.10
+joblib>=0.17.0


### PR DESCRIPTION
All tests passing.

Use `np.ma.MaskedArray` directly instead of importing from sklearn's version and import from `joblib` directly instead of `sklearn.externals`. It's more proper to export directly instead of relying on sklearn externals and exposed packages which have no guarantees for maintenance and accessibility.

As a rule of thumb, don't use publicly-exposed sklearn internal functions/tools when building a package for others because there will very likely be future dependency issues as things become deprecated and disappear.

Thank you guys so much for building this tool for the community. I've tried to use Dask's version, but their implementation doesn't seem to work with XGBoost that doesn't implement partial_fit() or something.

I'll continue to chip-in as I can if I encounter any further issues, thanks.