### PR TITLE
prep release 0.3.0, drop support for python < 3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ notifications:
     email: false
 language: python
 python:
-    - "2.7"
-    - "3.4"
-    - "3.5"
     - "3.6"
     - "3.7"
     - "3.8"
@@ -13,7 +10,6 @@ install:
     - pip install -r dev-requirements.txt
     - pip install -r requirements.txt
     - pip install cython ; python_version==3.6
-    - pip install pandas==0.19 ; python_version==3.5
     - pip install -e .
     - pip list
 before_script: flake8 civismlext

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [0.3.0] - 2020-10-28
+### Changed
+- Fix dependencies to make stacking compatible with scikit-learn 0.23+ (#54)
+- Removed support for Python <3.6. (#55)
+
 ## [0.2.1] - 2020-01-15
 ### Changed
 - Make stacking compatible with scikit-learn v0.22.1. (#52)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,5 @@
 pytest~=3.2
 flake8
 nose
-mock==2.0.0 ; python_version >= '2.7' and python_version < '3.0'
 # Estimator checks in test_preprocessing are sklearn>0.20 only
 scikit-learn>=0.20

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,6 @@
 joblib>=0.14.0
 numpy>=1.12,<2.0
-pandas>=0.25; python_version >= '3.5'
-pandas>=0.19,<0.21; python_version == '3.4'
-pandas>=0.19,<=0.23; python_version == '2.7'
+pandas>=0.25
 scikit-learn>=0.18.1
 scipy>=0.14,<2.0
 six~=1.10

--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,22 @@
 import os
 from setuptools import find_packages, setup
 
+CLASSIFIERS = [
+    'Programming Language :: Python',
+    'Programming Language :: Python :: 3',
+    'Programming Language :: Python :: 3.6',
+    'Programming Language :: Python :: 3.7',
+    'Programming Language :: Python :: 3.8',
+    'Programming Language :: Python :: 3 :: Only',
+]
+
 
 def read(fname):
     with open(os.path.join(os.path.dirname(__file__), fname)) as _in:
         return _in.read()
 
 
-_VERSION = '0.2.1'
+_VERSION = '0.3.0'
 
 setup(version=_VERSION,
       name="civisml-extensions",
@@ -20,4 +29,5 @@ setup(version=_VERSION,
       long_description=read('README.rst'),
       long_description_content_type='text/x-rst',
       include_package_data=True,
-      license="BSD-3")
+      license="BSD-3",
+      classifiers=CLASSIFIERS)

--- a/setup.py
+++ b/setup.py
@@ -30,4 +30,5 @@ setup(version=_VERSION,
       long_description_content_type='text/x-rst',
       include_package_data=True,
       license="BSD-3",
-      classifiers=CLASSIFIERS)
+      classifiers=CLASSIFIERS,
+      python_requires=">=3.6")


### PR DESCRIPTION
This is primarily to release changes in #54 