### PR TITLE
add upper bound <0.24.0 for scikit-learn requirement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## [0.3.1] - 2020-03-15
+### Changed
+- Added upper bound `<0.24.0` for scikit-learn version (#59)
+
 ## [0.3.0] - 2020-10-28
 ### Changed
 - Fix dependencies to make stacking compatible with scikit-learn 0.23+ (#54)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 joblib>=0.14.0
 numpy>=1.12,<2.0
 pandas>=0.25
-scikit-learn>=0.18.1
+scikit-learn>=0.18.1,<0.24.0
 scipy>=0.14,<2.0
 six~=1.10

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def read(fname):
         return _in.read()
 
 
-_VERSION = '0.3.0'
+_VERSION = '0.3.1'
 
 setup(version=_VERSION,
       name="civisml-extensions",


### PR DESCRIPTION
The master branch build currently [fails](https://travis-ci.com/github/civisanalytics/civisml-extensions/builds/219950425) because this package doesn't work with scikit-learn 0.24.x.

This adds an upper bound, at least for now, to the package requirements and prepares for a bugfix release.